### PR TITLE
Fix pkgdown workflow: bump deprecated action versions

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown
+          extra-packages: any::pkgdown, local::.
           needs: website
 
       - name: Build site (PR check, no deploy)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,7 +1,9 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
+    branches: [main, master]
+  pull_request:
     branches: [main, master]
   release:
     types: [published]
@@ -12,23 +14,30 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: pkgdown
+          extra-packages: any::pkgdown
           needs: website
 
-      - name: Deploy package
+      - name: Build site (PR check, no deploy)
+        if: github.event_name == 'pull_request'
+        run: Rscript -e 'pkgdown::build_site(new_process = FALSE, install = FALSE)'
+
+      - name: Deploy site
+        if: github.event_name != 'pull_request'
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Fixes the silently-failing pkgdown workflow caused by GitHub's late-2024 deprecation of `actions/cache@v2`, which `r-lib/actions@v1` pulls in transitively.
- Bumps `actions/checkout` and the `r-lib/actions` family to v2/v4.
- Adds a `pull_request` trigger with a build-only check (no deploy) so future workflow edits can be validated without risking the live docs site.

## Background

Both pushes to `main` since 2026-04-09 (the CLAUDE.md and cleanup-batch commits) failed within ~10s during the "Set up job" step with:

> This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`.

The live site at rmbl-sdp.github.io/rSDP is **not currently broken** — it's still serving the last successful build's content from `gh-pages`, which a failed workflow doesn't touch.

## Test plan

- [ ] PR check (build-only) runs to completion on this PR — validates the workflow boots, installs deps, and `pkgdown::build_site()` succeeds against the current code without ever touching `gh-pages`
- [ ] If green, merge to `main`
- [ ] Confirm the post-merge workflow run on `main` is also green
- [ ] Spot-check rmbl-sdp.github.io/rSDP to confirm the site still loads after redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)